### PR TITLE
Add access-control-allow-origin option

### DIFF
--- a/analysis.properties
+++ b/analysis.properties
@@ -17,3 +17,4 @@ local-cache=cache
 light-threads=3
 heavy-threads=3
 max-workers=8
+access-control-allow-origin=http://localhost:3000


### PR DESCRIPTION
Hi,

Thanks for docker-compose. I've just tried it and the current version require now an access-control-allow-origin option, so here it is!